### PR TITLE
Allow a const ref return type

### DIFF
--- a/include/javabind/binding.hpp
+++ b/include/javabind/binding.hpp
@@ -105,7 +105,7 @@ namespace javabind
     struct MemberAdapter
     {
         template <typename R>
-        using java_t = typename ArgType<R>::type::java_type;
+        using java_t = typename ArgType<std::decay_t<R>>::type::java_type;
 
         using result_type = decltype((std::declval<T>().*func)(std::declval<Args>()...));
 
@@ -123,7 +123,7 @@ namespace javabind
                 }
                 if constexpr (!std::is_same_v<result_type, void>) {
                     auto&& result = (ptr->*func)(ArgType<std::decay_t<Args>>::type::native_value(env, args)...);
-                    return ArgType<result_type>::type::java_value(env, std::move(result));
+                    return ArgType<std::decay_t<result_type>>::type::java_value(env, std::move(result));
                 }
                 else {
                     (ptr->*func)(ArgType<std::decay_t<Args>>::type::native_value(env, args)...);

--- a/include/javabind/function.hpp
+++ b/include/javabind/function.hpp
@@ -66,8 +66,8 @@ namespace javabind
     {
         using native_type = std::function<Result(Arg)>;
         using java_type = jobject;
-        using java_arg_type = typename ArgType<Arg>::type::java_type;
-        using java_result_type = typename ArgType<Result>::type::java_type;
+        using java_arg_type = typename ArgType<std::decay_t<Arg>>::type::java_type;
+        using java_result_type = typename ArgType<std::decay_t<Result>>::type::java_type;
 
         static native_type native_value(JNIEnv* env, java_type obj)
         {
@@ -91,7 +91,7 @@ namespace javabind
                     }
 
                     if constexpr (!std::is_same_v<Result, void>) {
-                        auto ret = WrapperType::native_invoke(env, fun.ref(), invoke.ref(), ArgType<Arg>::type::java_value(env, arg));
+                        auto ret = WrapperType::native_invoke(env, fun.ref(), invoke.ref(), ArgType<std::decay_t<Arg>>::type::java_value(env, arg));
                         if constexpr (std::is_same_v<decltype(ret), jobject>) {
                             // ensure proper deallocation for jobject
                             LocalObjectRef res = LocalObjectRef(env, ret);
@@ -109,7 +109,7 @@ namespace javabind
                         }
                     }
                     else {
-                        WrapperType::native_invoke(env, fun.ref(), invoke.ref(), ArgType<Arg>::type::java_value(env, arg));
+                        WrapperType::native_invoke(env, fun.ref(), invoke.ref(), ArgType<std::decay_t<Arg>>::type::java_value(env, arg));
                         if (env->ExceptionCheck()) {
                             throw JavaException(env);
                         }
@@ -366,7 +366,7 @@ namespace javabind
         using native_type = std::function<void(Arg)>;
 
         constexpr static std::string_view class_name = "java.util.function.Consumer";
-        constexpr static std::string_view java_name = GenericTraits<class_name, Arg>::java_name;
+        constexpr static std::string_view java_name = GenericTraits<class_name, std::decay_t<Arg>>::java_name;
         constexpr static std::string_view sig = "Ljava/util/function/Consumer;";
         constexpr static std::string_view native_class_path = "hu/info/hunyadi/javabind/NativeConsumer";
 

--- a/include/javabind/signature.hpp
+++ b/include/javabind/signature.hpp
@@ -11,6 +11,7 @@
 #pragma once
 #include "type.hpp"
 #include "string.hpp"
+#include <type_traits>
 
 namespace javabind
 {
@@ -38,14 +39,14 @@ namespace javabind
 
         constexpr static std::string_view comma = ", ";
         constexpr static std::string_view param_sig = join_v<ArgType<Args>::type::sig...>;
-        constexpr static std::string_view return_sig = ArgType<R>::type::sig;
+        constexpr static std::string_view return_sig = ArgType<std::decay_t<R>>::type::sig;
 
     public:
         /** Java signature string used internally for type lookup. */
         constexpr static std::string_view sig = callable_sig<param_sig, return_sig>::value;
 
         constexpr static std::string_view param_display = join_sep_v<comma, ArgType<Args>::type::java_name...>;
-        constexpr static std::string_view return_display = ArgType<R>::type::java_name;
+        constexpr static std::string_view return_display = ArgType<std::decay_t<R>>::type::java_name;
     };
 
     /**


### PR DESCRIPTION
Used std::decay_t when using the return type in ArgType<T>