### PR TITLE
Maps and sets with primitive types

### DIFF
--- a/include/javabind/core.hpp
+++ b/include/javabind/core.hpp
@@ -718,6 +718,7 @@ namespace javabind
     template <> struct ArgType<int64_t> { using type = JavaLongType; };
     template <> struct ArgType<float> { using type = JavaFloatType; };
     template <> struct ArgType<double> { using type = JavaDoubleType; };
+    template <> struct ArgType<std::size_t> { using type = JavaLongType; };
     template <> struct ArgType<std::string> { using type = JavaStringType; };
     template <> struct ArgType<std::string_view> { using type = JavaUTF8StringViewType; };
     template <> struct ArgType<std::u16string_view> { using type = JavaUTF16StringViewType; };

--- a/include/javabind/javabind.hpp
+++ b/include/javabind/javabind.hpp
@@ -35,6 +35,7 @@ namespace javabind
         for (auto&& [class_name, bindings] : FunctionBindings::value) {
             std::string simple_class_name;
             std::size_t found = class_name.rfind('/');
+
             if (found != std::string::npos) {
                 simple_class_name = class_name.substr(found + 1);
             }

--- a/java/hu/info/hunyadi/test/StaticSample.java
+++ b/java/hu/info/hunyadi/test/StaticSample.java
@@ -157,4 +157,10 @@ public class StaticSample {
     public static native Map<String, Rectangle> pass_ordered_map(Map<String, Rectangle> map);
 
     public static native Map<String, Rectangle> pass_unordered_map(Map<String, Rectangle> map);
+
+    public static native Set<Integer> pass_ordered_set_with_int_key(Set<Integer> set);
+
+    public static native java.util.Map<Integer, String> pass_ordered_map_with_int_key(java.util.Map<Integer, String> map);
+
+    public static native java.util.Map<String, Integer> pass_ordered_map_with_int_value(java.util.Map<String, Integer> map);
 }

--- a/java/hu/info/hunyadi/test/TestJavaBind.java
+++ b/java/hu/info/hunyadi/test/TestJavaBind.java
@@ -151,6 +151,7 @@ public class TestJavaBind {
                 .equals(List.of(new Rectangle(1.0, 2.0), new Rectangle(3.0, 4.0)));
         assert StaticSample.pass_ordered_set(Set.of("one", "two", "three")).equals(Set.of("one", "two", "three"));
         assert StaticSample.pass_unordered_set(Set.of("one", "two", "three")).equals(Set.of("one", "two", "three"));
+        assert StaticSample.pass_ordered_set_with_int_key(Set.of(1, 2, 3)).equals(Set.of(1, 2, 3));
 
         Map<String, Rectangle> rectangles = Map.ofEntries(
                 entry("a", new Rectangle(1.0, 2.0)),
@@ -158,6 +159,8 @@ public class TestJavaBind {
                 entry("c", new Rectangle(5.0, 6.0)));
         assert StaticSample.pass_ordered_map(rectangles).equals(rectangles);
         assert StaticSample.pass_unordered_map(rectangles).equals(rectangles);
+        assert StaticSample.pass_ordered_map_with_int_key(Map.of(1, "one", 2, "two", 3, "three")).equals(Map.of(1, "one", 2, "two", 3, "three"));
+        assert StaticSample.pass_ordered_map_with_int_value(Map.of("one", 1, "two", 2, "three", 3)).equals(Map.of("one", 1, "two", 2, "three", 3));
         System.out.println("PASS: collections");
     }
 }

--- a/test/javabind.cpp
+++ b/test/javabind.cpp
@@ -497,6 +497,9 @@ JAVA_EXTENSION_MODULE()
         .function<StaticSample::pass_collection<std::unordered_set<std::string>>>("pass_unordered_set")
         .function<StaticSample::pass_collection<std::map<std::string, Rectangle>>>("pass_ordered_map")
         .function<StaticSample::pass_collection<std::unordered_map<std::string, Rectangle>>>("pass_unordered_map")
+        .function<StaticSample::pass_collection<std::set<int>>>("pass_ordered_set_with_int_key")
+        .function<StaticSample::pass_collection<std::map<int, std::string>>>("pass_ordered_map_with_int_key")
+        .function<StaticSample::pass_collection<std::map<std::string, int>>>("pass_ordered_map_with_int_value")
         ;
 
 


### PR DESCRIPTION
Allows to pass C++ sets and maps with a primitive type from C++ to Java. If it's a primitive type it will be translated in Java to the boxed type.