### PR TITLE
std::optional support

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ javabind recognizes several widely-used types and marshals them automatically be
 | `std::unordered_set<E>` | `java.util.Set<E>` | `java.util.HashSet<E>` |
 | `std::map<K,V>` | `java.util.Map<K,V>` | `java.util.TreeMap<K,V>` |
 | `std::unordered_map<K,V>` | `java.util.Map<K,V>` | `java.util.HashMap<K,V>` |
+| `std::optional<T>` | `T` | `T` |
 | `std::function<R(T)>` | `Function<T,R>` | `NativeFunction<T,R>` implements `Function<T,R>` |
 | `std::function<R(int32_t)>` | `IntFunction<R>` | `NativeIntFunction<R>` implements `IntFunction<R>` |
 | `std::function<R(int64_t)>` | `LongFunction<R>` | `NativeLongFunction<R>` implements `LongFunction<R>` |
@@ -192,6 +193,8 @@ javabind recognizes several widely-used types and marshals them automatically be
 `boxed` is a lightweight C++ wrapper defined by the library to match Java boxed types such as `java.lang.Integer`. `boxed` has no C++ run-time overhead, it is only used for disambiguation.
 
 Collection types are copied between C++ and Java.
+
+Optionals are converted to a null-value in Java when they don't have a value in C++. Null-values are converted to an empty optional in C++.
 
 C++ types `basic_string_view<T>` translate to JNI calls `GetPrimitiveArrayCritical` and `ReleasePrimitiveArrayCritical` to get a direct pointer to the memory managed by the Java Virtual Machine (JVM). This imposes [significant restrictions](https://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#GetPrimitiveArrayCritical_ReleasePrimitiveArrayCritical):
 

--- a/include/javabind/binding.hpp
+++ b/include/javabind/binding.hpp
@@ -15,6 +15,7 @@
 #include "record.hpp"
 #include "function.hpp"
 #include "collection.hpp"
+#include "optional.hpp"
 
 #include "exception.hpp"
 #include "message.hpp"

--- a/include/javabind/optional.hpp
+++ b/include/javabind/optional.hpp
@@ -34,14 +34,18 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, java_type javaOptional)
         {
-            if (javaOptional == nullptr) return std::nullopt;
-            return arg_type_t<boxed_t<T>>::native_value(env, static_cast<typename arg_type_t<boxed_t<T>>::java_type>(javaOptional));
+            if (javaOptional == nullptr)
+                return std::nullopt;
+            else
+                return arg_type_t<boxed_t<T>>::native_value(env, static_cast<typename arg_type_t<boxed_t<T>>::java_type>(javaOptional));
         }
 
         static java_type java_value(JNIEnv* env, const native_type& nativeOptional)
         {
-            if (!nativeOptional.has_value()) return nullptr;
-            return arg_type_t<boxed_t<T>>::java_value(env, nativeOptional.value());
+            if (!nativeOptional.has_value())
+                return nullptr;
+            else
+                return arg_type_t<boxed_t<T>>::java_value(env, nativeOptional.value());
         }
     };
 

--- a/include/javabind/optional.hpp
+++ b/include/javabind/optional.hpp
@@ -1,0 +1,49 @@
+/**
+ * javabind: effective C++ and Java interoperability
+ * @see https://github.com/hunyadi/javabind
+ *
+ * Copyright (c) 2024 Levente Hunyadi
+ *
+ * This work is licensed under the terms of the MIT license.
+ * For a copy, see <https://opensource.org/licenses/MIT>.
+ */
+
+#pragma once
+#include "object.hpp"
+#include "signature.hpp"
+#include <optional>
+
+namespace javabind
+{
+    template <typename T>
+    struct ClassTraits<std::optional<T>>
+    {
+        constexpr static std::string_view class_name = arg_type_t<T>::class_name;
+        constexpr static std::string_view class_path = arg_type_t<T>::class_path;
+        constexpr static std::string_view java_name = arg_type_t<T>::java_name;
+    };
+
+    /**
+     * Converts a C++ optional with an object into a Java List.
+     */
+    template <typename T>
+    struct JavaOptionalType : AssignableJavaType<std::optional<T>>
+    {
+        using native_type = std::optional<T>;
+        using java_type = jobject;
+
+        static native_type native_value(JNIEnv* env, java_type javaOptional)
+        {
+            if (javaOptional == nullptr) return std::nullopt;
+            return arg_type_t<boxed_t<T>>::native_value(env, static_cast<typename arg_type_t<boxed_t<T>>::java_type>(javaOptional));
+        }
+
+        static java_type java_value(JNIEnv* env, const native_type& nativeOptional)
+        {
+            if (!nativeOptional.has_value()) return nullptr;
+            return arg_type_t<boxed_t<T>>::java_value(env, nativeOptional.value());
+        }
+    };
+
+    template <typename T> struct ArgType<std::optional<T>> { using type = JavaOptionalType<T>; };
+}

--- a/java/hu/info/hunyadi/test/StaticSample.java
+++ b/java/hu/info/hunyadi/test/StaticSample.java
@@ -163,4 +163,8 @@ public class StaticSample {
     public static native java.util.Map<Integer, String> pass_ordered_map_with_int_key(java.util.Map<Integer, String> map);
 
     public static native java.util.Map<String, Integer> pass_ordered_map_with_int_value(java.util.Map<String, Integer> map);
+
+    public static native Rectangle pass_optional_rectangle(Rectangle rectangle);
+
+    public static native Integer pass_optional_int(Integer i);
 }

--- a/java/hu/info/hunyadi/test/TestJavaBind.java
+++ b/java/hu/info/hunyadi/test/TestJavaBind.java
@@ -162,5 +162,12 @@ public class TestJavaBind {
         assert StaticSample.pass_ordered_map_with_int_key(Map.of(1, "one", 2, "two", 3, "three")).equals(Map.of(1, "one", 2, "two", 3, "three"));
         assert StaticSample.pass_ordered_map_with_int_value(Map.of("one", 1, "two", 2, "three", 3)).equals(Map.of("one", 1, "two", 2, "three", 3));
         System.out.println("PASS: collections");
+
+        assert StaticSample.pass_optional_rectangle(null) == null;
+        assert StaticSample.pass_optional_rectangle(new Rectangle(1.0, 2.0)).equals(new Rectangle(1.0, 2.0));
+        assert StaticSample.pass_optional_int(null) == null;
+        assert StaticSample.pass_optional_int(23).equals(23);
+        System.out.println("PASS: optional");
+
     }
 }

--- a/test/javabind.cpp
+++ b/test/javabind.cpp
@@ -10,6 +10,7 @@
 
 #include <javabind/javabind.hpp>
 #include <charconv>
+#include <optional>
 #include <vector>
 
 template <typename K, typename V>
@@ -74,6 +75,17 @@ template <typename K, typename V>
 std::ostream& operator<<(std::ostream& os, const std::unordered_map<K, V>& set)
 {
     return write_set(os, set);
+}
+
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::optional<T>& opt)
+{
+    if (opt.has_value()) {
+        return os << "{" << opt.value() << "}";
+    }
+    else {
+        return os << "{nullopt}";
+    }
 }
 
 struct Rectangle
@@ -344,6 +356,13 @@ struct StaticSample
         JAVA_OUTPUT << "pass_collection(" << collection << ")" << std::endl;
         return C(collection.begin(), collection.end());
     }
+
+    template <typename T>
+    static std::optional<T> pass_optional(const std::optional<T>& opt)
+    {
+        JAVA_OUTPUT << "pass_optional(" << opt << ")" << std::endl;
+        return opt;
+    }
 };
 
 struct Residence
@@ -500,8 +519,11 @@ JAVA_EXTENSION_MODULE()
         .function<StaticSample::pass_collection<std::set<int>>>("pass_ordered_set_with_int_key")
         .function<StaticSample::pass_collection<std::map<int, std::string>>>("pass_ordered_map_with_int_key")
         .function<StaticSample::pass_collection<std::map<std::string, int>>>("pass_ordered_map_with_int_value")
-        ;
 
+        // optional
+        .function<StaticSample::pass_optional<Rectangle>>("pass_optional_rectangle")
+        .function<StaticSample::pass_optional<int>>("pass_optional_int")
+        ;
 
     native_class<Person>()
         .constructor<Person(std::string)>("create")


### PR DESCRIPTION
std::optional<X> is converted to a null reference to X in Java and vice versa for objects,
std::optional<Y> is converted to a null reference to it's boxed type in Java and vice versa for arithmetic values.