### PR TITLE
Fix compilation on MSVC

### DIFF
--- a/include/javabind/optional.hpp
+++ b/include/javabind/optional.hpp
@@ -19,8 +19,6 @@ namespace javabind
     struct ClassTraits<std::optional<T>>
     {
         constexpr static std::string_view class_name = arg_type_t<T>::class_name;
-        constexpr static std::string_view class_path = arg_type_t<T>::class_path;
-        constexpr static std::string_view java_name = arg_type_t<T>::java_name;
     };
 
     /**

--- a/java/hu/info/hunyadi/test/StaticSample.java
+++ b/java/hu/info/hunyadi/test/StaticSample.java
@@ -191,4 +191,6 @@ public class StaticSample {
     public static native Rectangle pass_optional_rectangle(Rectangle rectangle);
 
     public static native Integer pass_optional_int(Integer i);
+
+    public static native String pass_optional_string(String s);
 }

--- a/java/hu/info/hunyadi/test/TestJavaBind.java
+++ b/java/hu/info/hunyadi/test/TestJavaBind.java
@@ -188,6 +188,8 @@ public class TestJavaBind {
         assert StaticSample.pass_optional_rectangle(new Rectangle(1.0, 2.0)).equals(new Rectangle(1.0, 2.0));
         assert StaticSample.pass_optional_int(null) == null;
         assert StaticSample.pass_optional_int(23).equals(23);
+        assert StaticSample.pass_optional_string(null) == null;
+        assert StaticSample.pass_optional_string("ok").equals("ok");
         System.out.println("PASS: optional");
 
     }

--- a/test/javabind.cpp
+++ b/test/javabind.cpp
@@ -609,6 +609,7 @@ JAVA_EXTENSION_MODULE()
         // optional
         .function<StaticSample::pass_optional<Rectangle>>("pass_optional_rectangle")
         .function<StaticSample::pass_optional<int>>("pass_optional_int")
+        .function<StaticSample::pass_optional<std::string>>("pass_optional_string")
         ;
 
     native_class<Person>()


### PR DESCRIPTION
optional<std::string> doesn't compile on MSVC because it tries to access JavaStringType::class_path which isn't defined