### PR TITLE
Codegen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(header_files ${JAVABIND_LIBRARY_HEADERS})
 add_library(javabind INTERFACE)
 target_sources(javabind INTERFACE "$<BUILD_INTERFACE:${header_files}>")
 target_include_directories(javabind INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include/>)
+target_link_libraries(javabind INTERFACE JNI::JNI)
 
 if(JAVABIND_INTEGER_WIDENING_CONVERSION)
     target_compile_definitions(javabind INTERFACE JAVABIND_INTEGER_WIDENING_CONVERSION)
@@ -40,9 +41,11 @@ endif()
 
 # shared library for unit tests
 add_library(javabind_native SHARED test/javabind.cpp)
-add_dependencies(javabind_native javabind)
-target_include_directories(javabind_native PRIVATE ${JNI_INCLUDE_DIRS})
-target_link_libraries(javabind_native PRIVATE javabind ${JAVA_JVM_LIBRARY})
+target_link_libraries(javabind_native PRIVATE javabind)
+
+# code generator
+add_executable(javabind_codegen codegen/main.cpp)
+target_link_libraries(javabind_codegen PRIVATE javabind_native javabind)
 
 # installer
 install(DIRECTORY include/javabind DESTINATION include)

--- a/codegen/main.cpp
+++ b/codegen/main.cpp
@@ -1,0 +1,15 @@
+#include "javabind/codegen.hpp"
+#include <iostream>
+
+JNIEXPORT void codegen(const std::filesystem::path& output_path);
+
+int main(int argc, char** argv)
+{
+    if (argc != 2)
+    {
+        std::cout << "Usage: " << argv[0] << " OUTPUT_DIRECTORY" << std::endl;
+        return -1;
+    }
+    codegen(argv[1]);
+    return 0;
+}

--- a/include/javabind/codegen.hpp
+++ b/include/javabind/codegen.hpp
@@ -96,9 +96,7 @@ namespace javabind
 
         if (extends_native_object)
         {
-            os << "import hu.info.hunyadi.javabind.NativeObject;\n";
-            os << "\n";
-            os << "public class " << class_name << " extends NativeObject {\n";
+            os << "public class " << class_name << " extends hu.info.hunyadi.javabind.NativeObject {\n";
         }
         else
         {

--- a/include/javabind/codegen.hpp
+++ b/include/javabind/codegen.hpp
@@ -1,0 +1,158 @@
+/**
+ * javabind: effective C++ and Java interoperability
+ * @see https://github.com/hunyadi/javabind
+ *
+ * Copyright (c) 2024 Levente Hunyadi
+ *
+ * This work is licensed under the terms of the MIT license.
+ * For a copy, see <https://opensource.org/licenses/MIT>.
+ */
+
+#pragma once
+#include "binding.hpp"
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+
+namespace javabind
+{
+    static inline constexpr std::string_view indent = "    ";
+
+    struct ClassDescription
+    {
+        static std::tuple<std::string_view, std::string_view> split_on_last_char(std::string_view str, char ch)
+        {
+            auto pos = str.rfind(ch);
+            if (pos == std::string::npos) return std::make_tuple("", str);
+            return std::make_tuple(str.substr(0, pos), str.substr(pos + 1));
+        }
+
+        static std::string replace(std::string_view str, char old_value, char new_value)
+        {
+            std::string result { str };
+            std::replace(result.begin(), result.end(), old_value, new_value);
+            return result;
+        }
+
+        static ClassDescription from_full_name(std::string_view full_name)
+        {
+            auto [package_name, name] = split_on_last_char(full_name, '.');
+            return ClassDescription { name, package_name, replace(package_name, '.', '/') };
+        }
+
+        static ClassDescription from_full_path(std::string_view full_path)
+        {
+            auto [package_path, name] = split_on_last_char(full_path, '/');
+            return ClassDescription { name, replace(package_path, '/', '.'), package_path };
+        }
+
+        static ClassDescription from_signature(std::string_view signature)
+        {
+            return from_full_path(signature.substr(1, signature.size() - 2));
+        }
+
+        ClassDescription(std::string_view name, std::string_view package_name, std::string_view package_path)
+            : name { name }
+            , package_name { package_name }
+            , package_path { package_path }
+        {
+        }
+
+        std::string name;
+        std::string package_name;
+        std::string package_path;
+    };
+
+    static void write_enum_class(std::ostream& os, std::string_view class_name, const javabind::EnumBinding& binding)
+    {
+        os << "public enum " << class_name << " {\n";
+
+        for (std::size_t i = 0; i < binding.names().size(); ++i)
+        {
+            os << indent << binding.names().at(i);
+            if (i != binding.names().size() - 1) os << ",";
+            os << "\n";
+        }
+        os << "}\n";
+    }
+
+    static void write_record_class(std::ostream& os, std::string_view class_name, const std::vector<javabind::FieldBinding>& bindings)
+    {
+        os << "public record " << class_name << "(\n";
+
+        for (std::size_t i = 0; i < bindings.size(); ++i)
+        {
+            os << indent << bindings.at(i).type << " " << bindings.at(i).name;
+            if (i != bindings.size() - 1) os << ",\n";
+        }
+        os << ") {\n";
+        os << "}\n";
+    }
+
+    static void write_native_class(std::ostream& os, std::string_view class_name, const std::vector<javabind::FunctionBinding>& bindings)
+    {
+        os << "import hu.info.hunyadi.javabind.NativeObject;\n";
+        os << "\n";
+        os << "public class " << class_name << " extends NativeObject {\n";
+
+        for (auto&& binding : bindings)
+        {
+            if (!binding.is_member)
+            {
+                os << indent << "public static native " << binding.return_display << " " << binding.name << "(" << binding.param_display << ");\n";
+            }
+        }
+        for (auto&& binding : bindings)
+        {
+            if (binding.is_member)
+            {
+                os << indent << "public native " << binding.return_display << " " << binding.name << "(" << binding.param_display << ");\n";
+            }
+        }
+        os << "}\n";
+    }
+
+    template<typename ContentWriter>
+    static void write_class(const std::filesystem::path& output_dir, const ClassDescription& class_desc, ContentWriter writer)
+    {
+        std::filesystem::path output_path = output_dir / class_desc.package_path;
+        std::filesystem::path output_filename = output_path / (class_desc.name + ".java");
+        std::filesystem::create_directories(output_path);
+        std::ofstream os { output_filename };
+
+        if (!os)
+        {
+            std::cerr << "Failed to open file: " << output_filename << std::endl;
+            return;
+        }
+        os << "package " << class_desc.package_name << ";\n";
+        os << "\n";
+        writer(os, class_desc.name);
+        os.close();
+    }
+
+    void codegen(const std::filesystem::path& output_path)
+    {
+        for (const auto& [enum_class_name, bindings] : javabind::EnumBindings::value)
+        {
+            ClassDescription class_desc = ClassDescription::from_full_name(enum_class_name);
+            write_class(output_path, class_desc, [&bindings](auto& stream, const auto& class_name) {
+                write_enum_class(stream, class_name, bindings);
+            });
+        }
+        for (const auto& [record_class_sig, bindings] : javabind::FieldBindings::value)
+        {
+            ClassDescription class_desc = ClassDescription::from_signature(record_class_sig);
+            write_class(output_path, class_desc, [&bindings](auto& stream, const auto& class_name) {
+                write_record_class(stream, class_name, bindings);
+            });
+        }
+        for (const auto& [native_class_name, bindings] : javabind::FunctionBindings::value)
+        {
+            ClassDescription class_desc = ClassDescription::from_full_name(native_class_name);
+            write_class(output_path, class_desc, [&bindings](auto& stream, const auto& class_name) {
+                write_native_class(stream, class_name, bindings);
+            });
+        }
+    }
+}

--- a/include/javabind/codegen.hpp
+++ b/include/javabind/codegen.hpp
@@ -91,9 +91,19 @@ namespace javabind
 
     static void write_native_class(std::ostream& os, std::string_view class_name, const std::vector<javabind::FunctionBinding>& bindings)
     {
-        os << "import hu.info.hunyadi.javabind.NativeObject;\n";
-        os << "\n";
-        os << "public class " << class_name << " extends NativeObject {\n";
+        auto is_close_method = [](const auto& binding) { return binding.name == "close" && binding.signature == FunctionTraits<void()>::sig; };
+        auto extends_native_object = std::any_of(bindings.begin(), bindings.end(), is_close_method);
+
+        if (extends_native_object)
+        {
+            os << "import hu.info.hunyadi.javabind.NativeObject;\n";
+            os << "\n";
+            os << "public class " << class_name << " extends NativeObject {\n";
+        }
+        else
+        {
+            os << "public class " << class_name << " {\n";
+        }
 
         for (auto&& binding : bindings)
         {

--- a/include/javabind/javabind.hpp
+++ b/include/javabind/javabind.hpp
@@ -30,65 +30,17 @@ namespace javabind
         // imports
         os << "import hu.info.hunyadi.javabind.NativeObject;\n\n";
 
-        for (auto&& [enum_name, bindings] : EnumBindings::value) {
-            std::string_view simple_enum_name = strip_until_last(enum_name, '.');
-
-            // enum definition
-            os << "public enum " << simple_enum_name << " {\n";
-
-            // enum values
-            for (std::size_t i = 0; i < bindings.names().size(); i++) {
-                if (i != bindings.names().size() - 1) {
-                    os << "    " << bindings.names()[i] << ",\n";
-                } else {
-                    os << "    " << bindings.names()[i] << "\n";
-                }
-            }
-
-            // end of class definition
-            os << "}\n";
+        for (auto&& [enum_class_name, bindings] : EnumBindings::value) {
+            ClassDescription class_desc = ClassDescription::from_full_name(enum_class_name);
+            write_enum_class(os, class_desc.name, bindings);
         }
-
-        for (auto&& [class_name, bindings] : FieldBindings::value) {
-            std::string_view simple_class_name = strip_until_last(class_name, '/');
-            simple_class_name = simple_class_name.substr(0, simple_class_name.size() - 1);
-
-            // class definition
-            os << "public record " << simple_class_name << "(";
-
-            for (std::size_t i = 0; i < bindings.size(); i++) {
-                if (i != bindings.size() - 1) {
-                    os << bindings[i].type << " " << bindings[i].name << ", ";
-                } else {
-                    os << bindings[i].type << " " << bindings[i].name;
-                }
-            }
-            os << ") {\n";
-            os << "}\n";
+        for (const auto& [record_class_sig, bindings] : javabind::FieldBindings::value) {
+            ClassDescription class_desc = ClassDescription::from_signature(record_class_sig);
+            write_record_class(os, class_desc.name, bindings);
         }
-
-        for (auto&& [class_name, bindings] : FunctionBindings::value) {
-            std::string_view simple_class_name = strip_until_last(class_name, '.');
-
-            // class definition
-            os << "public class " << simple_class_name << " extends NativeObject {\n";
-
-            // static methods
-            for (auto&& binding : bindings) {
-                if (!binding.is_member) {
-                    os << "    public static native " << binding.return_display << " " << binding.name << "(" << binding.param_display << ");\n";
-                }
-            }
-
-            // instance methods
-            for (auto&& binding : bindings) {
-                if (binding.is_member) {
-                    os << "    public native " << binding.return_display << " " << binding.name << "(" << binding.param_display << ");\n";
-                }
-            }
-
-            // end of class definition
-            os << "}\n";
+        for (const auto& [native_class_name, bindings] : javabind::FunctionBindings::value) {
+            ClassDescription class_desc = ClassDescription::from_full_name(native_class_name);
+            write_native_class(os, class_desc.name, bindings);
         }
     }
 

--- a/java/hu/info/hunyadi/test/TestJavaBind.java
+++ b/java/hu/info/hunyadi/test/TestJavaBind.java
@@ -158,9 +158,9 @@ public class TestJavaBind {
             person.setName("Dalma");
             assert person.getName().equals("Dalma");
 
-            assert person.getResidence().getCity().equals("Budapest");
+            assert person.getResidence().city().equals("Budapest");
             person.setResidence(vienna);
-            assert person.getResidence().getCity().equals("Wien");
+            assert person.getResidence().city().equals("Wien");
 
             person.setChildren(List.of(Person.create("Bela"), Person.create("Cecil")));
             assert person.getChildren().size() == 2;

--- a/test/javabind.cpp
+++ b/test/javabind.cpp
@@ -8,6 +8,7 @@
  * For a copy, see <https://opensource.org/licenses/MIT>.
  */
 
+#include <javabind/codegen.hpp>
 #include <javabind/javabind.hpp>
 #include <charconv>
 #include <optional>
@@ -664,6 +665,10 @@ JAVA_EXTENSION_MODULE()
         .value(FooBar::Foo, "Foo")
         .value(FooBar::Bar, "Bar")
         ;
+}
 
-    print_registered_bindings();
+JNIEXPORT void codegen(const std::filesystem::path& output_path)
+{
+    java_bindings_initializer();
+    javabind::codegen(output_path);
 }


### PR DESCRIPTION
A utility method that can be used to generated the required java code.

I haven't updated the java code that is committed in the repo but you could update it with `build/javabind_codgen java`. It will compile and the tests succeed with the generated code.

Codegen could also be integrated in the CMakeLists.txt and then the java native classes could be removed from the repo (although for documentation purposes you might want to keep them in here).