### PR TITLE
Throw NullPointerException when a null pointer is passed to C++

### DIFF
--- a/include/javabind/chrono.hpp
+++ b/include/javabind/chrono.hpp
@@ -74,6 +74,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, java_type javaValue)
         {
+            if (javaValue == nullptr) {
+                throw JavaNullPointerException(env, "Duration is null");
+            }
             LocalClassRef durationClass(env, javaValue);
             auto toNative = durationClass.getMethod(JavaDurationTraits<native_type>::to_native_method, "()J");
             return native_type{ env->CallLongMethod(javaValue, toNative.ref()) / JavaDurationTraits<native_type>::factor };
@@ -95,6 +98,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, java_type javaValue)
         {
+            if (javaValue == nullptr) {
+                throw JavaNullPointerException(env, "Instant is null");
+            }
             LocalClassRef instantClass(env, javaValue);
             auto getEpochSecond = instantClass.getMethod("getEpochSecond", "()J");
             auto getNano = instantClass.getMethod("getNano", "()I");

--- a/include/javabind/collection.hpp
+++ b/include/javabind/collection.hpp
@@ -265,6 +265,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, java_type javaList)
         {
+            if (javaList == nullptr) {
+                throw JavaNullPointerException(env, msg() << java_name << " is null");
+            }
             list_view<element_type> view(env, javaList);
             native_type nativeList;
             std::size_t size = view.size();
@@ -307,6 +310,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, java_type javaSet)
         {
+            if (javaSet == nullptr) {
+                throw JavaNullPointerException(env, msg() << java_name << " is null");
+            }
             set_view<element_type> view(env, javaSet);
             set_view_iterator<element_type> iterator = view.iterator();
             native_type nativeSet;
@@ -353,6 +359,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, java_type javaMap)
         {
+            if (javaMap == nullptr) {
+                throw JavaNullPointerException(env, msg() << java_name << " is null");
+            }
             map_view<key_type, value_type> view(env, javaMap);
             map_view_iterator<key_type, value_type> iterator = view.iterator();
             native_type nativeMap;

--- a/include/javabind/core.hpp
+++ b/include/javabind/core.hpp
@@ -9,7 +9,9 @@
  */
 
 #pragma once
+#include "exception.hpp"
 #include "local.hpp"
+#include "message.hpp"
 #include "type.hpp"
 #include "string.hpp"
 #include "view.hpp"
@@ -498,6 +500,9 @@ namespace javabind
          */
         static native_type native_value(JNIEnv* env, java_type obj)
         {
+            if (obj == nullptr) {
+                throw JavaNullPointerException(env, msg() << java_name << " is null");
+            }
             // unbox from object
             LocalClassRef cls(env, obj);
             Method getValue = cls.getMethod(get_value_func.data(), get_value_func_sig);
@@ -545,6 +550,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, java_type value)
         {
+            if (value == nullptr) {
+                throw JavaNullPointerException(env, "String is null");
+            }
             jsize len = env->GetStringUTFLength(value);
             std::string s;
             if (len > 0) {
@@ -583,6 +591,9 @@ namespace javabind
 
         static wrapped_string_view native_value(JNIEnv* env, java_type value)
         {
+            if (value == nullptr) {
+                throw JavaNullPointerException(env, "String is null");
+            }
             return wrapped_string_view(env, value);
         }
 
@@ -603,6 +614,9 @@ namespace javabind
 
         static wrapped_u16string_view native_value(JNIEnv* env, java_type value)
         {
+            if (value == nullptr) {
+                throw JavaNullPointerException(env, "String is null");
+            }
             return wrapped_u16string_view(env, value);
         }
 
@@ -647,6 +661,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, jarray arr)
         {
+            if (arr == nullptr) {
+                throw JavaNullPointerException(env, msg() << java_name << " is null");
+            }
             std::size_t len = env->GetArrayLength(arr);
             native_type vec(len);
             arg_type_t<T>::native_array_value(env, arr, vec.data(), vec.size());
@@ -669,6 +686,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, jarray arr)
         {
+            if (arr == nullptr) {
+                throw JavaNullPointerException(env, "boolean[] is null");
+            }
             std::size_t len = env->GetArrayLength(arr);
             native_type vec;
             vec.reserve(len);

--- a/include/javabind/enum.hpp
+++ b/include/javabind/enum.hpp
@@ -83,6 +83,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, java_type javaEnumValue)
         {
+            if (javaEnumValue == nullptr) {
+                throw JavaNullPointerException(env, msg() << "Enum " << class_name << " is null");
+            }
             LocalClassRef enum_class(env, javaEnumValue);
 
             try {

--- a/include/javabind/function.hpp
+++ b/include/javabind/function.hpp
@@ -71,6 +71,9 @@ namespace javabind
 
         static native_type native_value(JNIEnv* env, java_type obj)
         {
+            if (obj == nullptr) {
+                throw JavaNullPointerException(env, "Function is null");
+            }
             GlobalObjectRef fun = GlobalObjectRef(env, obj);
             LocalClassRef cls(env, fun.ref());
             Method invoke = cls.getMethod(WrapperType::apply_fn, WrapperType::apply_sig);  // lifecycle bound to object reference

--- a/include/javabind/local.hpp
+++ b/include/javabind/local.hpp
@@ -41,6 +41,12 @@ namespace javabind
             }
         }
 
+        JavaException(jthrowable ex, std::string_view message)
+            : ex(ex)
+            , message(message)
+        {
+        }
+
         /**
          * Exceptions must not be copied as they contain a JNI local reference.
          */
@@ -63,6 +69,26 @@ namespace javabind
     private:
         jthrowable ex = nullptr;
         std::string message;
+    };
+
+    /**
+     * An exception that will be throw as java.lang.NullPointerException.
+     */
+    struct JavaNullPointerException : public JavaException
+    {
+        JavaNullPointerException(JNIEnv* env, std::string message)
+            : JavaException(new_exception(env, message), message)
+        {
+        }
+
+        jthrowable new_exception(JNIEnv* env, std::string message)
+        {
+            jclass cls = env->FindClass("java/lang/NullPointerException");
+            jmethodID init = env->GetMethodID(cls, "<init>", "(Ljava/lang/String;)V");
+            jobject exception = env->NewObject(cls, init, message);
+            env->DeleteLocalRef(cls);
+            return static_cast<jthrowable>(exception);
+        }
     };
 
     class LocalClassRef;

--- a/include/javabind/record.hpp
+++ b/include/javabind/record.hpp
@@ -56,6 +56,9 @@ namespace javabind
 
         static T native_value(JNIEnv* env, jobject obj)
         {
+            if (obj == nullptr) {
+                throw JavaNullPointerException(env, msg() << java_name << " is null");
+            }
             LocalClassRef objClass(env, obj);
 
             T native_object = T();

--- a/java/hu/info/hunyadi/test/TestJavaBind.java
+++ b/java/hu/info/hunyadi/test/TestJavaBind.java
@@ -14,6 +14,15 @@ public class TestJavaBind {
         return source.replace(' ', '_');
     }
 
+    public static void assertThrowsNullPointerException(Runnable runnable) {
+        try {
+            runnable.run();
+            assert false;
+        } catch (Exception e) {
+            assert NullPointerException.class.isInstance(e);
+        }
+    }
+
     public static void main(String[] args) {
         System.out.println("LOAD: Java host application");
         System.loadLibrary("javabind_native");
@@ -55,6 +64,12 @@ public class TestJavaBind {
         assert StaticSample.pass_string("ok").equals("ok");
         assert StaticSample.pass_utf8_string("árvíztűrő tükörfúrógép").equals("árvíztűrő tükörfúrógép");
         StaticSample.pass_utf16_string("árvíztűrő tükörfúrógép");
+        assertThrowsNullPointerException(() -> StaticSample.pass_foo_bar(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_nanoseconds(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_time_point(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_string(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_utf8_string(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_utf16_string(null));
         System.out.println("PASS: class functions with simple types");
 
         assert StaticSample.pass_cast_byte(Byte.MIN_VALUE, "128") == Byte.MIN_VALUE;
@@ -75,6 +90,7 @@ public class TestJavaBind {
         assert StaticSample.pass_boxed_integer(Integer.valueOf(23)).equals(Integer.valueOf(23));
         assert StaticSample.pass_boxed_long(Long.MAX_VALUE).equals(Long.MAX_VALUE);
         assert StaticSample.pass_boxed_double(-Double.MAX_VALUE).equals(-Double.MAX_VALUE);
+        assertThrowsNullPointerException(() -> StaticSample.pass_boxed_boolean(null));
         System.out.println("PASS: class functions with boxed types");
 
         boolean[] bool_array = new boolean[] { true, false, false };
@@ -97,6 +113,8 @@ public class TestJavaBind {
         assert Arrays.equals(StaticSample.pass_long_array_view(long_array), long_array);
         assert Arrays.equals(StaticSample.pass_float_array_view(float_array), float_array);
         assert Arrays.equals(StaticSample.pass_double_array_view(double_array), double_array);
+        assertThrowsNullPointerException(() -> StaticSample.pass_bool_array(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_int_array(null));
         System.out.println("PASS: class functions with array types");
 
         assert StaticSample.pass_function("my string", s -> "'" + s + "'").equals("my string -> 'my string'");
@@ -108,11 +126,13 @@ public class TestJavaBind {
         StaticSample.apply_long_consumer(1989l, val -> System.out.println(val));
         StaticSample.apply_double_consumer(3.14159265359, val -> System.out.println(val));
         StaticSample.apply_string_consumer("start to finish", val -> System.out.println(val));
+        assertThrowsNullPointerException(() -> StaticSample.apply_int_consumer(23, null));
 
         assert StaticSample.apply_int_predicate(23, val -> val > 0);
         assert StaticSample.apply_long_predicate(1989l, val -> val > 0l);
         assert StaticSample.apply_double_predicate(3.14159265359, val -> val > 0.0);
         assert StaticSample.apply_string_predicate("start to finish", val -> val.startsWith("start"));
+        assertThrowsNullPointerException(() -> StaticSample.apply_int_predicate(23, null));
 
         assert StaticSample.apply_int_to_string_function(123, val -> String.valueOf(val)).equals("123");
         assert StaticSample.apply_long_to_string_function(456789, val -> String.valueOf(val)).equals("456789");
@@ -146,6 +166,7 @@ public class TestJavaBind {
         PrimitiveRecord source = new PrimitiveRecord((byte) 1, '@', (short) 2, 3, 4l, 5.0f, 6.0);
         PrimitiveRecord target = new PrimitiveRecord((byte) 2, '@', (short) 4, 6, 8l, 10.0f, 12.0);
         assert StaticSample.transform_record(source).equals(target);
+        assertThrowsNullPointerException(() -> StaticSample.pass_record(null));
         System.out.println("PASS: record class");
 
         try (Sample obj = Sample.create()) {
@@ -195,6 +216,11 @@ public class TestJavaBind {
                 .equals(Map.of(1, "one", 2, "two", 3, "three"));
         assert StaticSample.pass_ordered_map_with_int_value(Map.of("one", 1, "two", 2, "three", 3))
                 .equals(Map.of("one", 1, "two", 2, "three", 3));
+        assertThrowsNullPointerException(() -> StaticSample.pass_list(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_ordered_set(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_unordered_set(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_ordered_map(null));
+        assertThrowsNullPointerException(() -> StaticSample.pass_unordered_map(null));
         System.out.println("PASS: collections");
 
         assert StaticSample.pass_optional_rectangle(null) == null;


### PR DESCRIPTION
Currently when a null pointer is passed to C++ the library crashes. I changed it so that a java NullPointerException is thrown, except when the type is optional because in that case a null pointer is converted to nullopt.